### PR TITLE
Hiding references to Rapid ATO

### DIFF
--- a/backup/index.html
+++ b/backup/index.html
@@ -1,0 +1,298 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Planning for ATO at CMS</title>
+    <script src="assets/uswds-2.11.1/js/uswds-init.min.js"></script>
+    <link rel="stylesheet" href="assets/uswds-2.11.1/css/uswds.min.css" />
+  </head>
+  <body>
+    <script src="assets/uswds-2.11.1/js/uswds.min.js"></script>
+
+    <a class="usa-skipnav" href="#main-content">Skip to main content</a>
+  
+<!--
+    <section class="usa-banner" aria-label="Official government website">
+      <div class="usa-accordion">
+        <header class="usa-banner__header">
+          <div class="usa-banner__inner">
+            <div class="grid-col-auto">
+              <img class="usa-banner__header-flag" src="/assets/img/us_flag_small.png" alt="U.S. flag">
+            </div>
+            <div class="grid-col-fill tablet:grid-col-auto">
+              <p class="usa-banner__header-text">An official website of the United States government</p>
+              <p class="usa-banner__header-action" aria-hidden="true">Here’s how you know</p>
+            </div>
+            <button class="usa-accordion__button usa-banner__button"
+              aria-expanded="false" aria-controls="gov-banner">
+              <span class="usa-banner__button-text">Here’s how you know</span>
+            </button>
+          </div>
+        </header>
+        <div class="usa-banner__content usa-accordion__content" id="gov-banner">
+          <div class="grid-row grid-gap-lg">
+            <div class="usa-banner__guidance tablet:grid-col-6">
+              <img class="usa-banner__icon usa-media-block__img" src="/assets/img/icon-dot-gov.svg" role="img" alt="" aria-hidden="true">
+              <div class="usa-media-block__body">
+                <p>
+                  <strong>
+                    Official websites use .gov
+    </strong>
+                  <br/>
+                  A <strong>.gov</strong> website belongs to an official government organization in the United States.
+    
+                </p>
+              </div>
+            </div>
+            <div class="usa-banner__guidance tablet:grid-col-6">
+              <img class="usa-banner__icon usa-media-block__img" src="/assets/img/icon-https.svg" role="img" alt="" aria-hidden="true">
+              <div class="usa-media-block__body">
+                <p>
+                  <strong>
+                    Secure .gov websites use HTTPS
+    </strong>
+                  <br/>
+                  A <strong>lock</strong> (
+    <span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title banner-lock-description" focusable="false"><title id="banner-lock-title">Lock</title><desc id="banner-lock-description">A locked padlock</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"/></svg></span>
+    ) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
+    
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    
+    -->
+      
+    
+    <div class="usa-overlay"></div>
+    <header class="usa-header usa-header--extended"><div class="usa-navbar">
+      <div class="usa-logo" id="extended-logo">
+        <em class="usa-logo__text"><a href="index.html" title="Home" aria-label="Home">CMS Security & Compliance Planning</a></em>
+      </div>
+      <button class="usa-menu-btn">Menu</button>
+    </div>
+    <nav aria-label="Primary navigation" class="usa-nav">
+        <div class="usa-nav__inner"><button class="usa-nav__close"><img src="/assets/img/usa-icons/close.svg" role="img" alt="close"></button>
+    <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item">
+        <button class="usa-accordion__button usa-nav__link  " aria-expanded="false" aria-controls="extended-nav-section-one"><span>CMS Rapid ATO</span></button>
+        <ul id="extended-nav-section-one" class="usa-nav__submenu">
+       
+                 
+          <li class="usa-nav__submenu-item">
+            <a href="rato.html" class=""> What is CMS Rapid ATO</a>
+          </li>
+          <li class="usa-nav__submenu-item">
+            <a href="overview.html" class=""> Background</a></ul></li><li class="usa-nav__primary-item">
+        <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="extended-nav-section-two"><span>ATO Phases</span></button>
+        <ul id="extended-nav-section-two" class="usa-nav__submenu">
+          
+        <!-- <li class="usa-nav__submenu-item">
+            <a href="#" class=""> Preparation</a>
+          </li>--> 
+          <li class="usa-nav__submenu-item">
+                  <a href="initiate.html" class=""> Initiate</a>
+                </li><li class="usa-nav__submenu-item">
+                  <a href="develop.html" class=""> Develop and Assess</a>
+                </li><li class="usa-nav__submenu-item">
+                  <a href="operate.html" class=""> Operate</a>
+                </li>
+              
+                <li class="usa-nav__submenu-item">
+                  <a href="retire.html" class=""> Retire</a>
+                </li>
+              </ul></li>
+
+
+           <!--  <li class="usa-nav__primary-item">
+                <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="extended-nav-section-three"><span>Security</span></button>
+                <ul id="extended-nav-section-three" class="usa-nav__submenu"><li class="usa-nav__submenu-item">
+                          <a href="#" class=""> General Security Standards</a>
+                        </li><li class="usa-nav__submenu-item">
+                          <a href="#" class=""> Incidents</a>
+                        </li>
+                      </ul></li>--> 
+              
+              
+                      <li class="usa-nav__primary-item">
+                        <button class="usa-accordion__button usa-nav__link " aria-expanded="false" aria-controls="extended-nav-section-three"><span>Resources</span></button>
+                        <ul id="extended-nav-section-three" class="usa-nav__submenu">
+                         <!-- <li class="usa-nav__submenu-item">
+                            <a href="#" class=""> Preparation</a>
+                          </li>-->
+                        <li class="usa-nav__submenu-item">
+                            <a href="types.html" class=""> Authorizations & Agreements   </a>
+
+                 
+                        </li><li class="usa-nav__submenu-item">
+                          <a href="roles.html" class=""> Key Roles & Stakeholders</a>
+                                </li>
+                              
+                                <li class="usa-nav__submenu-item">
+                                  <a href="tools.html" class=""> Tools & Services  </a>
+          
+                           
+                              </li>
+                              </ul></li></ul>
+    </div>
+    </div>
+      </nav>
+    </header>
+    
+    
+      
+    
+    <main id="main-content">
+      <section class="usa-hero" aria-label="Introduction">
+      <div class="grid-container">
+        <div class="usa-hero__callout">
+          <h1 class="usa-hero__heading"><span class="usa-hero__heading--alt">ATO at CMS</span>
+          </h1><p>From Waterfall to Iterative Security Planning </p><a class="usa-button" href="overview.html">Learn more</a>
+        </div>
+      </div>
+    </section>
+    
+    
+      
+      <section class="grid-container usa-section">
+        <div class="grid-row grid-gap">
+          <div class="tablet:grid-col-4">
+            <h2 class="font-heading-xl margin-top-0 tablet:margin-bottom-0">CMS Rapid ATO</h2>
+          </div>
+          <div class="tablet:grid-col-8 usa-prose">
+            <p>
+              The goal of <a href="rato.html">CMS Rapid ATO (rATO)</a> is to provide the CMS Security and Privacy community with the information and tools to plan, launch and maintain secure, compliant software. The cost of updating and addressing compliance issues after implementation is typically greater than integrating security and privacy requirements during development. This site is intended to help teams prepare and shift compliance left in their development process.</p>
+
+              <p><b>Rapid ATO</b> aims to simplify and streamline the ATO process in three initiatives:</p>
+<p>
+              <b>Iterative security planning</b></p>
+              <p>We don’t build software using waterfall methodologies any more. We build it iteratively so we can anticipate changes and adjust accordingly. This allows us to build better products cheaper. Why do we still do waterfall compliance?</p>
+              
+
+              <p><b>Blueprint Digital Service for CMS</b></p>
+              <p>Anyone who’s worked through an ATO knows that writing control implementation statements is one of the biggest challenges (see Develop and Assess phase). To lessen the load and streamline the process, we’re introducing the Digital Service platform and System Components. <a href="rato.html">Learn more</a>
+              </p>
+
+              <p><b>CMS Compliance Library</b></p>
+              <p>We know that every system won’t use this Digital Service to get an ATO—at least not yet. That’s why we’re making our System Components available to all in our CMS Compliance Library. <a href="rato.html">Learn more</a>
+              </p>
+
+              <br>
+              <br>
+              <br>
+              <br>
+              <br>
+              <br>
+              <br>
+    
+          </div>
+        </div>
+      </section>
+      <!--
+    
+      <section class="usa-graphic-list usa-section usa-section--dark">
+      <div class="grid-container">
+        <div class="usa-graphic-list__row grid-row grid-gap">
+          <div class="usa-media-block tablet:grid-col">
+            <img class="usa-media-block__img"  src="/assets/img/circle-124.png" alt="Icon">
+            <div class="usa-media-block__body">
+              <h2 class="usa-graphic-list__heading">For "a role"</h2>
+              <p>Graphic headings can be used a few different ways, depending on what your landing page is for. Highlight your values, specific program areas, or results.</p>
+            </div>
+          </div>
+          <div class="usa-media-block tablet:grid-col">
+            <img class="usa-media-block__img"  src="/assets/img/circle-124.png" alt="Icon">
+            <div class="usa-media-block__body">
+              <h2 class="usa-graphic-list__heading">Stick to 6 or fewer words.</h2>
+              <p>Keep body text to about 30 words. They can be shorter, but try to be somewhat balanced across all four. It creates a clean appearance with good spacing.</p>
+            </div>
+          </div>
+        </div>
+        <div class="usa-graphic-list__row grid-row grid-gap">
+          <div class="usa-media-block tablet:grid-col">
+            <img class="usa-media-block__img"  src="/assets/img/circle-124.png" alt="Icon">
+            <div class="usa-media-block__body">
+              <h2 class="usa-graphic-list__heading">Never highlight anything without a goal.</h2>
+              <p>For anything you want to highlight here, understand what your users know now, and what activity or impression you want from them after they see it.</p>
+            </div>
+          </div>
+          <div class="usa-media-block tablet:grid-col">
+            <img class="usa-media-block__img"  src="/assets/img/circle-124.png" alt="Icon">
+            <div class="usa-media-block__body">
+              <h2 class="usa-graphic-list__heading">Could also have 2 or 6.</h2>
+              <p>In addition to your goal, find out your users’ goals. What do they want to know or do that supports your mission? Use these headings to show those.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>-->
+    
+    
+    <!--  <section id="test-section-id" class="usa-section">
+        <div class="grid-container">
+          <h2 class="font-heading-xl margin-y-0">Section heading</h2>
+          <p class="usa-intro">Everything up to this point should help people understand your agency or project: who you are, your goal or mission, and how you approach it. Use this section to encourage them to act. Describe why they should get in touch here, and use an active verb on the button below. “Get in touch,” “Learn more,” and so on.</p>
+          <a class="usa-button usa-button--big" href="#">Call to action</a>
+        </div>
+      </section>-->
+    
+    </main>
+    
+    <footer class="usa-footer usa-footer--slim">
+        
+        <div class="usa-footer__primary-section">
+          <div class="usa-footer__primary-container grid-row">
+            <div class="mobile-lg:grid-col-8">
+              <nav class="usa-footer__nav" aria-label="Footer navigation">
+                <ul class="grid-row grid-gap">
+                  <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+                    <a class="usa-footer__primary-link" href="javascript:void(0);"></a>
+                  </li>
+                  <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+                    <a class="usa-footer__primary-link" href="javascript:void(0);"></a>
+                  </li>
+                  <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+                    <a class="usa-footer__primary-link" href="javascript:void(0);"></a>
+                  </li>
+                  <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+                    <a class="usa-footer__primary-link" href="javascript:void(0);"></a>
+                  </li>
+                </ul>
+              </nav>
+            </div>
+            <div class="mobile-lg:grid-col-4">
+              <address class="usa-footer__address">
+                <div class="grid-row grid-gap">
+                  <div class="grid-col-auto mobile-lg:grid-col-12 desktop:grid-col-auto">
+                    <div class="usa-footer__contact-info">
+                      <a href="tel:1-800-555-5555"></a>
+                    </div>
+                  </div>
+                  <div class="grid-col-auto mobile-lg:grid-col-12 desktop:grid-col-auto">
+                    <div class="usa-footer__contact-info">
+                      <a href="mailto:info@agency.gov"></a>
+                    </div>
+                  </div>
+                </div>
+              </address>
+            </div>
+          </div>
+        </div>
+        <div class="usa-footer__secondary-section">
+          <div class="grid-container">
+            <div class="usa-footer__logo grid-row grid-gap-2">
+              <div class="grid-col-auto">
+                <img class="usa-footer__logo-img" src="/assets/img/logo-img.png" alt="">
+              </div>
+              <div class="grid-col-auto">
+                <p class="usa-footer__logo-heading"></p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
+  </body>
+</html>

--- a/develop.html
+++ b/develop.html
@@ -79,7 +79,7 @@
         <div class="usa-nav__inner"><button class="usa-nav__close"><img src="/assets/img/usa-icons/close.svg" role="img" alt="close"></button>
    
    
-            <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item">
+            <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item" style="display: none">
         <button class="usa-accordion__button usa-nav__link  " aria-expanded="false" aria-controls="extended-nav-section-one"><span>CMS Rapid ATO</span></button>
         <ul id="extended-nav-section-one" class="usa-nav__submenu">
        

--- a/index.html
+++ b/index.html
@@ -11,288 +11,253 @@
     <script src="assets/uswds-2.11.1/js/uswds.min.js"></script>
 
     <a class="usa-skipnav" href="#main-content">Skip to main content</a>
-  
-<!--
-    <section class="usa-banner" aria-label="Official government website">
+
+    <!--
+      <section class="usa-banner" aria-label="Official government website">
       <div class="usa-accordion">
-        <header class="usa-banner__header">
-          <div class="usa-banner__inner">
-            <div class="grid-col-auto">
-              <img class="usa-banner__header-flag" src="/assets/img/us_flag_small.png" alt="U.S. flag">
-            </div>
-            <div class="grid-col-fill tablet:grid-col-auto">
-              <p class="usa-banner__header-text">An official website of the United States government</p>
-              <p class="usa-banner__header-action" aria-hidden="true">Here’s how you know</p>
-            </div>
-            <button class="usa-accordion__button usa-banner__button"
-              aria-expanded="false" aria-controls="gov-banner">
-              <span class="usa-banner__button-text">Here’s how you know</span>
-            </button>
-          </div>
-        </header>
-        <div class="usa-banner__content usa-accordion__content" id="gov-banner">
-          <div class="grid-row grid-gap-lg">
-            <div class="usa-banner__guidance tablet:grid-col-6">
-              <img class="usa-banner__icon usa-media-block__img" src="/assets/img/icon-dot-gov.svg" role="img" alt="" aria-hidden="true">
-              <div class="usa-media-block__body">
-                <p>
-                  <strong>
-                    Official websites use .gov
-    </strong>
-                  <br/>
-                  A <strong>.gov</strong> website belongs to an official government organization in the United States.
-    
-                </p>
-              </div>
-            </div>
-            <div class="usa-banner__guidance tablet:grid-col-6">
-              <img class="usa-banner__icon usa-media-block__img" src="/assets/img/icon-https.svg" role="img" alt="" aria-hidden="true">
-              <div class="usa-media-block__body">
-                <p>
-                  <strong>
-                    Secure .gov websites use HTTPS
-    </strong>
-                  <br/>
-                  A <strong>lock</strong> (
-    <span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title banner-lock-description" focusable="false"><title id="banner-lock-title">Lock</title><desc id="banner-lock-description">A locked padlock</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"/></svg></span>
-    ) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
-    
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
+      <header class="usa-banner__header">
+      <div class="usa-banner__inner">
+      <div class="grid-col-auto">
+      <img class="usa-banner__header-flag" src="/assets/img/us_flag_small.png" alt="U.S. flag">
       </div>
-    </section>
-    
+      <div class="grid-col-fill tablet:grid-col-auto">
+      <p class="usa-banner__header-text">An official website of the United States government</p>
+      <p class="usa-banner__header-action" aria-hidden="true">Here’s how you know</p>
+      </div>
+      <button class="usa-accordion__button usa-banner__button"
+      aria-expanded="false" aria-controls="gov-banner">
+      <span class="usa-banner__button-text">Here’s how you know</span>
+      </button>
+      </div>
+      </header>
+      <div class="usa-banner__content usa-accordion__content" id="gov-banner">
+      <div class="grid-row grid-gap-lg">
+      <div class="usa-banner__guidance tablet:grid-col-6">
+      <img class="usa-banner__icon usa-media-block__img" src="/assets/img/icon-dot-gov.svg" role="img" alt="" aria-hidden="true">
+      <div class="usa-media-block__body">
+      <p>
+      <strong>
+      Official websites use .gov
+      </strong>
+      <br/>
+      A <strong>.gov</strong> website belongs to an official government organization in the United States.
+
+      </p>
+      </div>
+      </div>
+      <div class="usa-banner__guidance tablet:grid-col-6">
+      <img class="usa-banner__icon usa-media-block__img" src="/assets/img/icon-https.svg" role="img" alt="" aria-hidden="true">
+      <div class="usa-media-block__body">
+      <p>
+      <strong>
+      Secure .gov websites use HTTPS
+      </strong>
+      <br/>
+      A <strong>lock</strong> (
+      <span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title banner-lock-description" focusable="false"><title id="banner-lock-title">Lock</title><desc id="banner-lock-description">A locked padlock</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"/></svg></span>
+      ) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
+
+      </p>
+      </div>
+      </div>
+      </div>
+      </div>
+      </div>
+      </section>
+
     -->
-      
-    
+
+
     <div class="usa-overlay"></div>
     <header class="usa-header usa-header--extended"><div class="usa-navbar">
-      <div class="usa-logo" id="extended-logo">
-        <em class="usa-logo__text"><a href="index.html" title="Home" aria-label="Home">CMS Security & Compliance Planning</a></em>
+        <div class="usa-logo" id="extended-logo">
+          <em class="usa-logo__text"><a href="index.html" title="Home" aria-label="Home">CMS Security & Compliance Planning</a></em>
+        </div>
+        <button class="usa-menu-btn">Menu</button>
       </div>
-      <button class="usa-menu-btn">Menu</button>
-    </div>
-    <nav aria-label="Primary navigation" class="usa-nav">
+      <nav aria-label="Primary navigation" class="usa-nav">
         <div class="usa-nav__inner"><button class="usa-nav__close"><img src="/assets/img/usa-icons/close.svg" role="img" alt="close"></button>
-    <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item">
-        <button class="usa-accordion__button usa-nav__link  " aria-expanded="false" aria-controls="extended-nav-section-one"><span>CMS Rapid ATO</span></button>
-        <ul id="extended-nav-section-one" class="usa-nav__submenu">
-       
-                 
-          <li class="usa-nav__submenu-item">
-            <a href="rato.html" class=""> What is CMS Rapid ATO</a>
-          </li>
-          <li class="usa-nav__submenu-item">
-            <a href="overview.html" class=""> Background</a></ul></li><li class="usa-nav__primary-item">
-        <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="extended-nav-section-two"><span>ATO Phases</span></button>
-        <ul id="extended-nav-section-two" class="usa-nav__submenu">
-          
-        <!-- <li class="usa-nav__submenu-item">
-            <a href="#" class=""> Preparation</a>
-          </li>--> 
-          <li class="usa-nav__submenu-item">
-                  <a href="initiate.html" class=""> Initiate</a>
-                </li><li class="usa-nav__submenu-item">
-                  <a href="develop.html" class=""> Develop and Assess</a>
-                </li><li class="usa-nav__submenu-item">
-                  <a href="operate.html" class=""> Operate</a>
-                </li>
-              
+
+
+          <ul class="usa-nav__primary usa-accordion">
+            <li class="usa-nav__primary-item" style="display:none">
+              <button class="usa-accordion__button usa-nav__link  " aria-expanded="false" aria-controls="extended-nav-section-one"><span>CMS Rapid ATO</span></button>
+              <ul id="extended-nav-section-one" class="usa-nav__submenu">
+
+
                 <li class="usa-nav__submenu-item">
-                  <a href="retire.html" class=""> Retire</a>
+                  <a href="rato.html" class=""> What is CMS Rapid ATO</a>
                 </li>
-              </ul></li>
+                <li class="usa-nav__submenu-item">
+                  <a href="overview.html" class=""> Background</a></ul></li>
+
+                <li class="usa-nav__primary-item">
+                  <button class="usa-accordion__button usa-nav__link usa-current" aria-expanded="false" aria-controls="extended-nav-section-two"><span>ATO Phases</span></button>
+                  <ul id="extended-nav-section-two" class="usa-nav__submenu">
+                    <!-- <li class="usa-nav__submenu-item">
+                      <a href="#" class=""> Preparation</a>
+                      </li>-->
 
 
-           <!--  <li class="usa-nav__primary-item">
-                <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="extended-nav-section-three"><span>Security</span></button>
-                <ul id="extended-nav-section-three" class="usa-nav__submenu"><li class="usa-nav__submenu-item">
-                          <a href="#" class=""> General Security Standards</a>
-                        </li><li class="usa-nav__submenu-item">
-                          <a href="#" class=""> Incidents</a>
-                        </li>
-                      </ul></li>--> 
-              
-              
+
+                      <li class="usa-nav__submenu-item">
+                        <a href="overview-phases.html" class=""> Overview</a>
+                      </li><li class="usa-nav__submenu-item">
+                        <a href="initiate.html" class=""> Initiate</a>
+                      </li><li class="usa-nav__submenu-item">
+                        <a href="develop.html" class=""> Develop and Assess</a>
+                      </li><li class="usa-nav__submenu-item">
+                        <a href="operate.html" class=""> Operate</a>
+                      </li>
+                      <li class="usa-nav__submenu-item">
+                        <a href="retire.html" class=""> Retire</a>
+                      </li></ul></li>
+
+
+
                       <li class="usa-nav__primary-item">
-                        <button class="usa-accordion__button usa-nav__link " aria-expanded="false" aria-controls="extended-nav-section-three"><span>Resources</span></button>
+                        <button class="usa-accordion__button usa-nav__link usa-current" aria-expanded="false" aria-controls="extended-nav-section-three"><span>Resources</span></button>
                         <ul id="extended-nav-section-three" class="usa-nav__submenu">
-                         <!-- <li class="usa-nav__submenu-item">
+                          <!-- <li class="usa-nav__submenu-item">
                             <a href="#" class=""> Preparation</a>
-                          </li>-->
-                        <li class="usa-nav__submenu-item">
-                            <a href="types.html" class=""> Authorizations & Agreements   </a>
+                            </li>-->
+                            <li class="usa-nav__submenu-item">
+                              <a href="types.html" class=""> Authorizations & Agreements   </a>
 
-                 
-                        </li><li class="usa-nav__submenu-item">
-                          <a href="roles.html" class=""> Key Roles & Stakeholders</a>
-                                </li>
-                              
-                                <li class="usa-nav__submenu-item">
-                                  <a href="tools.html" class=""> Tools & Services  </a>
-          
-                           
-                              </li>
-                              </ul></li></ul>
-    </div>
-    </div>
+
+                            </li>
+
+                            <li class="usa-nav__submenu-item">
+                              <a href="roles.html" class=""> Key Roles & Stakeholders</a>
+                            </li>
+
+                            <li class="usa-nav__submenu-item">
+                              <a href="tools.html" class=""> Tools & Services  </a>
+
+
+                            </li>
+
+                        </ul></li></ul>
+        </div>
       </nav>
     </header>
-    
-    
-      
-    
+
+
+
+
     <main id="main-content">
-      <section class="usa-hero" aria-label="Introduction">
-      <div class="grid-container">
-        <div class="usa-hero__callout">
-          <h1 class="usa-hero__heading"><span class="usa-hero__heading--alt">ATO at CMS</span>
-          </h1><p>From Waterfall to Iterative Security Planning </p><a class="usa-button" href="overview.html">Learn more</a>
-        </div>
-      </div>
-    </section>
-    
-    
-      
-      <section class="grid-container usa-section">
-        <div class="grid-row grid-gap">
-          <div class="tablet:grid-col-4">
-            <h2 class="font-heading-xl margin-top-0 tablet:margin-bottom-0">CMS Rapid ATO</h2>
-          </div>
-          <div class="tablet:grid-col-8 usa-prose">
-            <p>
-              The goal of <a href="rato.html">CMS Rapid ATO (rATO)</a> is to provide the CMS Security and Privacy community with the information and tools to plan, launch and maintain secure, compliant software. The cost of updating and addressing compliance issues after implementation is typically greater than integrating security and privacy requirements during development. This site is intended to help teams prepare and shift compliance left in their development process.</p>
 
-              <p><b>Rapid ATO</b> aims to simplify and streamline the ATO process in three initiatives:</p>
-<p>
-              <b>Iterative security planning</b></p>
-              <p>We don’t build software using waterfall methodologies any more. We build it iteratively so we can anticipate changes and adjust accordingly. This allows us to build better products cheaper. Why do we still do waterfall compliance?</p>
-              
-
-              <p><b>Blueprint Digital Service for CMS</b></p>
-              <p>Anyone who’s worked through an ATO knows that writing control implementation statements is one of the biggest challenges (see Develop and Assess phase). To lessen the load and streamline the process, we’re introducing the Digital Service platform and System Components. <a href="rato.html">Learn more</a>
-              </p>
-
-              <p><b>CMS Compliance Library</b></p>
-              <p>We know that every system won’t use this Digital Service to get an ATO—at least not yet. That’s why we’re making our System Components available to all in our CMS Compliance Library. <a href="rato.html">Learn more</a>
-              </p>
-
-              <br>
-              <br>
-              <br>
-              <br>
-              <br>
-              <br>
-              <br>
-    
-          </div>
-        </div>
-      </section>
-      <!--
-    
-      <section class="usa-graphic-list usa-section usa-section--dark">
-      <div class="grid-container">
-        <div class="usa-graphic-list__row grid-row grid-gap">
-          <div class="usa-media-block tablet:grid-col">
-            <img class="usa-media-block__img"  src="/assets/img/circle-124.png" alt="Icon">
-            <div class="usa-media-block__body">
-              <h2 class="usa-graphic-list__heading">For "a role"</h2>
-              <p>Graphic headings can be used a few different ways, depending on what your landing page is for. Highlight your values, specific program areas, or results.</p>
-            </div>
-          </div>
-          <div class="usa-media-block tablet:grid-col">
-            <img class="usa-media-block__img"  src="/assets/img/circle-124.png" alt="Icon">
-            <div class="usa-media-block__body">
-              <h2 class="usa-graphic-list__heading">Stick to 6 or fewer words.</h2>
-              <p>Keep body text to about 30 words. They can be shorter, but try to be somewhat balanced across all four. It creates a clean appearance with good spacing.</p>
-            </div>
-          </div>
-        </div>
-        <div class="usa-graphic-list__row grid-row grid-gap">
-          <div class="usa-media-block tablet:grid-col">
-            <img class="usa-media-block__img"  src="/assets/img/circle-124.png" alt="Icon">
-            <div class="usa-media-block__body">
-              <h2 class="usa-graphic-list__heading">Never highlight anything without a goal.</h2>
-              <p>For anything you want to highlight here, understand what your users know now, and what activity or impression you want from them after they see it.</p>
-            </div>
-          </div>
-          <div class="usa-media-block tablet:grid-col">
-            <img class="usa-media-block__img"  src="/assets/img/circle-124.png" alt="Icon">
-            <div class="usa-media-block__body">
-              <h2 class="usa-graphic-list__heading">Could also have 2 or 6.</h2>
-              <p>In addition to your goal, find out your users’ goals. What do they want to know or do that supports your mission? Use these headings to show those.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>-->
-    
-    
-    <!--  <section id="test-section-id" class="usa-section">
+      <div class="usa-section">
         <div class="grid-container">
-          <h2 class="font-heading-xl margin-y-0">Section heading</h2>
-          <p class="usa-intro">Everything up to this point should help people understand your agency or project: who you are, your goal or mission, and how you approach it. Use this section to encourage them to act. Describe why they should get in touch here, and use an active verb on the button below. “Get in touch,” “Learn more,” and so on.</p>
-          <a class="usa-button usa-button--big" href="#">Call to action</a>
-        </div>
-      </section>-->
-    
-    </main>
-    
-    <footer class="usa-footer usa-footer--slim">
-        
-        <div class="usa-footer__primary-section">
-          <div class="usa-footer__primary-container grid-row">
-            <div class="mobile-lg:grid-col-8">
-              <nav class="usa-footer__nav" aria-label="Footer navigation">
-                <ul class="grid-row grid-gap">
-                  <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
-                    <a class="usa-footer__primary-link" href="javascript:void(0);"></a>
-                  </li>
-                  <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
-                    <a class="usa-footer__primary-link" href="javascript:void(0);"></a>
-                  </li>
-                  <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
-                    <a class="usa-footer__primary-link" href="javascript:void(0);"></a>
-                  </li>
-                  <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
-                    <a class="usa-footer__primary-link" href="javascript:void(0);"></a>
-                  </li>
-                </ul>
+          <div class="grid-row grid-gap">
+            <div class="usa-layout-docs__sidenav desktop:grid-col-3">
+              <nav aria-label="Secondary navigation">
+                <ul class="usa-sidenav">
+
+                  <li class="usa-sidenav__item">
+                    <a href="types.html" class="usa-current">Overview</a><ul class="usa-sidenav__sublist">
+                      <li class="usa-sidenav__item">
+                        <a href="initiate.html" class="">Initiate</a><ul class="usa-sidenav__sublist">
+
+
+                        </ul>
+                      </li>
+
+                      <li class="usa-sidenav__item">
+                        <a href="develop.html" class="">Develop and Assess</a><ul class="usa-sidenav__sublist">
+
+                        </ul>
+                      </li>
+
+                      <li class="usa-sidenav__item">
+                        <a href="operate.html" class="">Operate</a><ul class="usa-sidenav__sublist">
+
+                        </ul>
+                      </li>
+
+                      <li class="usa-sidenav__item">
+                        <a href="retire.html" class="">Retire</a><ul class="usa-sidenav__sublist">
+
+                        </ul>
+                      </li>
+
+
+
+
+                    </ul>
               </nav>
+
             </div>
-            <div class="mobile-lg:grid-col-4">
-              <address class="usa-footer__address">
-                <div class="grid-row grid-gap">
-                  <div class="grid-col-auto mobile-lg:grid-col-12 desktop:grid-col-auto">
-                    <div class="usa-footer__contact-info">
-                      <a href="tel:1-800-555-5555"></a>
-                    </div>
-                  </div>
-                  <div class="grid-col-auto mobile-lg:grid-col-12 desktop:grid-col-auto">
-                    <div class="usa-footer__contact-info">
-                      <a href="mailto:info@agency.gov"></a>
-                    </div>
+
+            <main class="usa-layout-docs__main desktop:grid-col-9 usa-prose usa-layout-docs" id="main-content">
+              <h1>Overview</h1>
+              <span style="display: none">
+                <p>The overarching goal of the Rapid ATO initiative is to modernize the ATO process and integrate security and compliance into the System Development Life Cycle (SDLC). </p>
+              </span>
+
+              <p>This section is intended to provide a high level overview, including many of the important steps required during each phase of the Authority to Operate (ATO) process. However, it does not include every detail and requirement along the way. </p>
+              <p>Please consult the linked resources embedded in these sections for additional information and guidance.&nbsp;</p>
+
+            </main>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <footer class="usa-footer usa-footer--slim">
+      <div class="grid-container usa-footer__return-to-top">
+        <!--- <a href="#">Return to top</a>-->
+      </div>
+      <div class="usa-footer__primary-section">
+        <div class="usa-footer__primary-container grid-row">
+          <div class="mobile-lg:grid-col-8">
+            <!-- <nav class="usa-footer__nav" aria-label="Footer navigation">
+              <ul class="grid-row grid-gap">
+              <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+              <a class="usa-footer__primary-link" href="javascript:void(0);">Primary link</a>
+              </li>
+              <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+              <a class="usa-footer__primary-link" href="javascript:void(0);">Primary link</a>
+              </li>
+              <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+              <a class="usa-footer__primary-link" href="javascript:void(0);">Primary link</a>
+              </li>
+              <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+              <a class="usa-footer__primary-link" href="javascript:void(0);">Primary link</a>
+              </li>
+              </ul>
+              </nav>-->
+          </div>
+          <div class="mobile-lg:grid-col-4">
+            <address class="usa-footer__address">
+              <div class="grid-row grid-gap">
+                <div class="grid-col-auto mobile-lg:grid-col-12 desktop:grid-col-auto">
+                  <div class="usa-footer__contact-info">
+                    <a href="tel:1-800-555-5555"></a>
                   </div>
                 </div>
-              </address>
+                <div class="grid-col-auto mobile-lg:grid-col-12 desktop:grid-col-auto">
+                  <div class="usa-footer__contact-info">
+                    <a href="mailto:info@agency.gov"></a>
+                  </div>
+                </div>
+              </div>
+            </address>
+          </div>
+        </div>
+      </div>
+      <div class="usa-footer__secondary-section">
+        <div class="grid-container">
+          <div class="usa-footer__logo grid-row grid-gap-2">
+            <div class="grid-col-auto">
+              <img class="usa-footer__logo-img" src="/assets/img/logo-img.png" alt="">
+            </div>
+            <div class="grid-col-auto">
+              <p class="usa-footer__logo-heading"></p>
             </div>
           </div>
         </div>
-        <div class="usa-footer__secondary-section">
-          <div class="grid-container">
-            <div class="usa-footer__logo grid-row grid-gap-2">
-              <div class="grid-col-auto">
-                <img class="usa-footer__logo-img" src="/assets/img/logo-img.png" alt="">
-              </div>
-              <div class="grid-col-auto">
-                <p class="usa-footer__logo-heading"></p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </footer>
+      </div>
+    </footer>
   </body>
 </html>

--- a/initiate.html
+++ b/initiate.html
@@ -79,7 +79,8 @@
         <div class="usa-nav__inner"><button class="usa-nav__close"><img src="/assets/img/usa-icons/close.svg" role="img" alt="close"></button>
    
    
-            <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item">
+            <ul class="usa-nav__primary usa-accordion">
+              <li class="usa-nav__primary-item" style="display: none">
         <button class="usa-accordion__button usa-nav__link  " aria-expanded="false" aria-controls="extended-nav-section-one"><span>CMS Rapid ATO</span></button>
         <ul id="extended-nav-section-one" class="usa-nav__submenu">
        

--- a/operate.html
+++ b/operate.html
@@ -79,7 +79,7 @@
         <div class="usa-nav__inner"><button class="usa-nav__close"><img src="/assets/img/usa-icons/close.svg" role="img" alt="close"></button>
    
    
-            <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item">
+            <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item" style="display: none">
         <button class="usa-accordion__button usa-nav__link  " aria-expanded="false" aria-controls="extended-nav-section-one"><span>CMS Rapid ATO</span></button>
         <ul id="extended-nav-section-one" class="usa-nav__submenu">
        

--- a/overview-phases.html
+++ b/overview-phases.html
@@ -11,250 +11,253 @@
     <script src="assets/uswds-2.11.1/js/uswds.min.js"></script>
 
     <a class="usa-skipnav" href="#main-content">Skip to main content</a>
-  
-<!--
-    <section class="usa-banner" aria-label="Official government website">
+
+    <!--
+      <section class="usa-banner" aria-label="Official government website">
       <div class="usa-accordion">
-        <header class="usa-banner__header">
-          <div class="usa-banner__inner">
-            <div class="grid-col-auto">
-              <img class="usa-banner__header-flag" src="/assets/img/us_flag_small.png" alt="U.S. flag">
-            </div>
-            <div class="grid-col-fill tablet:grid-col-auto">
-              <p class="usa-banner__header-text">An official website of the United States government</p>
-              <p class="usa-banner__header-action" aria-hidden="true">Here’s how you know</p>
-            </div>
-            <button class="usa-accordion__button usa-banner__button"
-              aria-expanded="false" aria-controls="gov-banner">
-              <span class="usa-banner__button-text">Here’s how you know</span>
-            </button>
-          </div>
-        </header>
-        <div class="usa-banner__content usa-accordion__content" id="gov-banner">
-          <div class="grid-row grid-gap-lg">
-            <div class="usa-banner__guidance tablet:grid-col-6">
-              <img class="usa-banner__icon usa-media-block__img" src="/assets/img/icon-dot-gov.svg" role="img" alt="" aria-hidden="true">
-              <div class="usa-media-block__body">
-                <p>
-                  <strong>
-                    Official websites use .gov
-    </strong>
-                  <br/>
-                  A <strong>.gov</strong> website belongs to an official government organization in the United States.
-    
-                </p>
-              </div>
-            </div>
-            <div class="usa-banner__guidance tablet:grid-col-6">
-              <img class="usa-banner__icon usa-media-block__img" src="/assets/img/icon-https.svg" role="img" alt="" aria-hidden="true">
-              <div class="usa-media-block__body">
-                <p>
-                  <strong>
-                    Secure .gov websites use HTTPS
-    </strong>
-                  <br/>
-                  A <strong>lock</strong> (
-    <span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title banner-lock-description" focusable="false"><title id="banner-lock-title">Lock</title><desc id="banner-lock-description">A locked padlock</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"/></svg></span>
-    ) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
-    
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
+      <header class="usa-banner__header">
+      <div class="usa-banner__inner">
+      <div class="grid-col-auto">
+      <img class="usa-banner__header-flag" src="/assets/img/us_flag_small.png" alt="U.S. flag">
       </div>
-    </section>
-    
+      <div class="grid-col-fill tablet:grid-col-auto">
+      <p class="usa-banner__header-text">An official website of the United States government</p>
+      <p class="usa-banner__header-action" aria-hidden="true">Here’s how you know</p>
+      </div>
+      <button class="usa-accordion__button usa-banner__button"
+      aria-expanded="false" aria-controls="gov-banner">
+      <span class="usa-banner__button-text">Here’s how you know</span>
+      </button>
+      </div>
+      </header>
+      <div class="usa-banner__content usa-accordion__content" id="gov-banner">
+      <div class="grid-row grid-gap-lg">
+      <div class="usa-banner__guidance tablet:grid-col-6">
+      <img class="usa-banner__icon usa-media-block__img" src="/assets/img/icon-dot-gov.svg" role="img" alt="" aria-hidden="true">
+      <div class="usa-media-block__body">
+      <p>
+      <strong>
+      Official websites use .gov
+      </strong>
+      <br/>
+      A <strong>.gov</strong> website belongs to an official government organization in the United States.
+
+      </p>
+      </div>
+      </div>
+      <div class="usa-banner__guidance tablet:grid-col-6">
+      <img class="usa-banner__icon usa-media-block__img" src="/assets/img/icon-https.svg" role="img" alt="" aria-hidden="true">
+      <div class="usa-media-block__body">
+      <p>
+      <strong>
+      Secure .gov websites use HTTPS
+      </strong>
+      <br/>
+      A <strong>lock</strong> (
+      <span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title banner-lock-description" focusable="false"><title id="banner-lock-title">Lock</title><desc id="banner-lock-description">A locked padlock</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"/></svg></span>
+      ) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
+
+      </p>
+      </div>
+      </div>
+      </div>
+      </div>
+      </div>
+      </section>
+
     -->
-      
-    
+
+
     <div class="usa-overlay"></div>
     <header class="usa-header usa-header--extended"><div class="usa-navbar">
-      <div class="usa-logo" id="extended-logo">
-        <em class="usa-logo__text"><a href="index.html" title="Home" aria-label="Home">CMS Security & Compliance Planning</a></em>
+        <div class="usa-logo" id="extended-logo">
+          <em class="usa-logo__text"><a href="index.html" title="Home" aria-label="Home">CMS Security & Compliance Planning</a></em>
+        </div>
+        <button class="usa-menu-btn">Menu</button>
       </div>
-      <button class="usa-menu-btn">Menu</button>
-    </div>
-    <nav aria-label="Primary navigation" class="usa-nav">
+      <nav aria-label="Primary navigation" class="usa-nav">
         <div class="usa-nav__inner"><button class="usa-nav__close"><img src="/assets/img/usa-icons/close.svg" role="img" alt="close"></button>
-   
-   
-            <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item">
-        <button class="usa-accordion__button usa-nav__link  " aria-expanded="false" aria-controls="extended-nav-section-one"><span>CMS Rapid ATO</span></button>
-        <ul id="extended-nav-section-one" class="usa-nav__submenu">
-       
-                 
-          <li class="usa-nav__submenu-item">
-            <a href="rato.html" class=""> What is CMS Rapid ATO</a>
-          </li>
-          <li class="usa-nav__submenu-item">
-            <a href="overview.html" class=""> Background</a></ul></li>
-                
-                <li class="usa-nav__primary-item">
-        <button class="usa-accordion__button usa-nav__link usa-current" aria-expanded="false" aria-controls="extended-nav-section-two"><span>ATO Phases</span></button>
-        <ul id="extended-nav-section-two" class="usa-nav__submenu">
-         <!-- <li class="usa-nav__submenu-item">
-            <a href="#" class=""> Preparation</a>
-          </li>-->
 
 
+          <ul class="usa-nav__primary usa-accordion">
+            <li class="usa-nav__primary-item" style="display:none">
+              <button class="usa-accordion__button usa-nav__link  " aria-expanded="false" aria-controls="extended-nav-section-one"><span>CMS Rapid ATO</span></button>
+              <ul id="extended-nav-section-one" class="usa-nav__submenu">
 
-          <li class="usa-nav__submenu-item">
-            <a href="overview-phases.html" class=""> Overview</a>
-        </li><li class="usa-nav__submenu-item">
-                  <a href="initiate.html" class=""> Initiate</a>
-                </li><li class="usa-nav__submenu-item">
-                  <a href="develop.html" class=""> Develop and Assess</a>
-                </li><li class="usa-nav__submenu-item">
-                  <a href="operate.html" class=""> Operate</a>
+
+                <li class="usa-nav__submenu-item">
+                  <a href="rato.html" class=""> What is CMS Rapid ATO</a>
                 </li>
                 <li class="usa-nav__submenu-item">
-                    <a href="retire.html" class=""> Retire</a>
-                  </li></ul></li>
+                  <a href="overview.html" class=""> Background</a></ul></li>
 
-                 
-
-                     <li class="usa-nav__primary-item">
-                    <button class="usa-accordion__button usa-nav__link usa-current" aria-expanded="false" aria-controls="extended-nav-section-three"><span>Resources</span></button>
-                    <ul id="extended-nav-section-three" class="usa-nav__submenu">
-                     <!-- <li class="usa-nav__submenu-item">
-                        <a href="#" class=""> Preparation</a>
+                <li class="usa-nav__primary-item">
+                  <button class="usa-accordion__button usa-nav__link usa-current" aria-expanded="false" aria-controls="extended-nav-section-two"><span>ATO Phases</span></button>
+                  <ul id="extended-nav-section-two" class="usa-nav__submenu">
+                    <!-- <li class="usa-nav__submenu-item">
+                      <a href="#" class=""> Preparation</a>
                       </li>-->
-                    <li class="usa-nav__submenu-item">
-                        <a href="types.html" class=""> Authorizations & Agreements   </a>
 
-                 
-                    </li>
-                    
-                    <li class="usa-nav__submenu-item">
-                      <a href="roles.html" class=""> Key Roles & Stakeholders</a>
-                            </li>
-                        
+
+
+                      <li class="usa-nav__submenu-item">
+                        <a href="overview-phases.html" class=""> Overview</a>
+                      </li><li class="usa-nav__submenu-item">
+                        <a href="initiate.html" class=""> Initiate</a>
+                      </li><li class="usa-nav__submenu-item">
+                        <a href="develop.html" class=""> Develop and Assess</a>
+                      </li><li class="usa-nav__submenu-item">
+                        <a href="operate.html" class=""> Operate</a>
+                      </li>
+                      <li class="usa-nav__submenu-item">
+                        <a href="retire.html" class=""> Retire</a>
+                      </li></ul></li>
+
+
+
+                      <li class="usa-nav__primary-item">
+                        <button class="usa-accordion__button usa-nav__link usa-current" aria-expanded="false" aria-controls="extended-nav-section-three"><span>Resources</span></button>
+                        <ul id="extended-nav-section-three" class="usa-nav__submenu">
+                          <!-- <li class="usa-nav__submenu-item">
+                            <a href="#" class=""> Preparation</a>
+                            </li>-->
                             <li class="usa-nav__submenu-item">
-                                <a href="tools.html" class=""> Tools & Services  </a>
-        
-                         
+                              <a href="types.html" class=""> Authorizations & Agreements   </a>
+
+
                             </li>
-                        
+
+                            <li class="usa-nav__submenu-item">
+                              <a href="roles.html" class=""> Key Roles & Stakeholders</a>
+                            </li>
+
+                            <li class="usa-nav__submenu-item">
+                              <a href="tools.html" class=""> Tools & Services  </a>
+
+
+                            </li>
+
                         </ul></li></ul>
-    </div>
+        </div>
       </nav>
     </header>
-    
-    
-      
-    
+
+
+
+
     <main id="main-content">
-      
-        <div class="usa-section">
-            <div class="grid-container">
-              <div class="grid-row grid-gap">
-                <div class="usa-layout-docs__sidenav desktop:grid-col-3">
-                  <nav aria-label="Secondary navigation">
-            <ul class="usa-sidenav">
-              
-             <li class="usa-sidenav__item">
-              <a href="types.html" class="usa-current">Overview</a><ul class="usa-sidenav__sublist">
-                <li class="usa-sidenav__item">
-                    <a href="initiate.html" class="">Initiate</a><ul class="usa-sidenav__sublist">
-                     
-                  
-              </ul>
-            </li>
 
-            <li class="usa-sidenav__item">
-                <a href="develop.html" class="">Develop and Assess</a><ul class="usa-sidenav__sublist">
-                 
-              </ul>
-            </li>
+      <div class="usa-section">
+        <div class="grid-container">
+          <div class="grid-row grid-gap">
+            <div class="usa-layout-docs__sidenav desktop:grid-col-3">
+              <nav aria-label="Secondary navigation">
+                <ul class="usa-sidenav">
 
-            <li class="usa-sidenav__item">
-                <a href="operate.html" class="">Operate</a><ul class="usa-sidenav__sublist">
-                 
-              </ul>
-            </li>
-
-            <li class="usa-sidenav__item">
-                <a href="retire.html" class="">Retire</a><ul class="usa-sidenav__sublist">
-                 
-              </ul>
-            </li>
+                  <li class="usa-sidenav__item">
+                    <a href="types.html" class="usa-current">Overview</a><ul class="usa-sidenav__sublist">
+                      <li class="usa-sidenav__item">
+                        <a href="initiate.html" class="">Initiate</a><ul class="usa-sidenav__sublist">
 
 
+                        </ul>
+                      </li>
 
-            
-            </ul>
-          </nav>
-          
-                </div>
-          
-                <main class="usa-layout-docs__main desktop:grid-col-9 usa-prose usa-layout-docs" id="main-content">
-                  <h1>Overview</h1>
-                  <p>The overarching goal of the Rapid ATO initiative is to modernize the ATO process and integrate security and compliance into the System Development Life Cycle (SDLC). </p>
-          
-                  <p>This section is intended to provide a high level overview, including many of the important steps required during each phase of the Authority to Operate (ATO) process. However, it does not include every detail and requirement along the way. </p>
-                  <p>Please consult the linked resources embedded in these sections for additional information and guidance.&nbsp;</p>
+                      <li class="usa-sidenav__item">
+                        <a href="develop.html" class="">Develop and Assess</a><ul class="usa-sidenav__sublist">
 
-                </main>
-              </div>
+                        </ul>
+                      </li>
+
+                      <li class="usa-sidenav__item">
+                        <a href="operate.html" class="">Operate</a><ul class="usa-sidenav__sublist">
+
+                        </ul>
+                      </li>
+
+                      <li class="usa-sidenav__item">
+                        <a href="retire.html" class="">Retire</a><ul class="usa-sidenav__sublist">
+
+                        </ul>
+                      </li>
+
+
+
+
+                    </ul>
+              </nav>
+
             </div>
+
+            <main class="usa-layout-docs__main desktop:grid-col-9 usa-prose usa-layout-docs" id="main-content">
+              <h1>Overview</h1>
+              <span style="display: none">
+                <p>The overarching goal of the Rapid ATO initiative is to modernize the ATO process and integrate security and compliance into the System Development Life Cycle (SDLC). </p>
+              </span>
+
+              <p>This section is intended to provide a high level overview, including many of the important steps required during each phase of the Authority to Operate (ATO) process. However, it does not include every detail and requirement along the way. </p>
+              <p>Please consult the linked resources embedded in these sections for additional information and guidance.&nbsp;</p>
+
+            </main>
           </div>
+        </div>
+      </div>
     </main>
-    
+
     <footer class="usa-footer usa-footer--slim">
-        <div class="grid-container usa-footer__return-to-top">
-         <!--- <a href="#">Return to top</a>-->
-        </div>
-        <div class="usa-footer__primary-section">
-          <div class="usa-footer__primary-container grid-row">
-            <div class="mobile-lg:grid-col-8">
-             <!-- <nav class="usa-footer__nav" aria-label="Footer navigation">
-                <ul class="grid-row grid-gap">
-                  <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
-                    <a class="usa-footer__primary-link" href="javascript:void(0);">Primary link</a>
-                  </li>
-                  <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
-                    <a class="usa-footer__primary-link" href="javascript:void(0);">Primary link</a>
-                  </li>
-                  <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
-                    <a class="usa-footer__primary-link" href="javascript:void(0);">Primary link</a>
-                  </li>
-                  <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
-                    <a class="usa-footer__primary-link" href="javascript:void(0);">Primary link</a>
-                  </li>
-                </ul>
+      <div class="grid-container usa-footer__return-to-top">
+        <!--- <a href="#">Return to top</a>-->
+      </div>
+      <div class="usa-footer__primary-section">
+        <div class="usa-footer__primary-container grid-row">
+          <div class="mobile-lg:grid-col-8">
+            <!-- <nav class="usa-footer__nav" aria-label="Footer navigation">
+              <ul class="grid-row grid-gap">
+              <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+              <a class="usa-footer__primary-link" href="javascript:void(0);">Primary link</a>
+              </li>
+              <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+              <a class="usa-footer__primary-link" href="javascript:void(0);">Primary link</a>
+              </li>
+              <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+              <a class="usa-footer__primary-link" href="javascript:void(0);">Primary link</a>
+              </li>
+              <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+              <a class="usa-footer__primary-link" href="javascript:void(0);">Primary link</a>
+              </li>
+              </ul>
               </nav>-->
-            </div>
-            <div class="mobile-lg:grid-col-4">
-              <address class="usa-footer__address">
-                <div class="grid-row grid-gap">
-                  <div class="grid-col-auto mobile-lg:grid-col-12 desktop:grid-col-auto">
-                    <div class="usa-footer__contact-info">
-                      <a href="tel:1-800-555-5555"></a>
-                    </div>
-                  </div>
-                  <div class="grid-col-auto mobile-lg:grid-col-12 desktop:grid-col-auto">
-                    <div class="usa-footer__contact-info">
-                      <a href="mailto:info@agency.gov"></a>
-                    </div>
+          </div>
+          <div class="mobile-lg:grid-col-4">
+            <address class="usa-footer__address">
+              <div class="grid-row grid-gap">
+                <div class="grid-col-auto mobile-lg:grid-col-12 desktop:grid-col-auto">
+                  <div class="usa-footer__contact-info">
+                    <a href="tel:1-800-555-5555"></a>
                   </div>
                 </div>
-              </address>
+                <div class="grid-col-auto mobile-lg:grid-col-12 desktop:grid-col-auto">
+                  <div class="usa-footer__contact-info">
+                    <a href="mailto:info@agency.gov"></a>
+                  </div>
+                </div>
+              </div>
+            </address>
+          </div>
+        </div>
+      </div>
+      <div class="usa-footer__secondary-section">
+        <div class="grid-container">
+          <div class="usa-footer__logo grid-row grid-gap-2">
+            <div class="grid-col-auto">
+              <img class="usa-footer__logo-img" src="/assets/img/logo-img.png" alt="">
+            </div>
+            <div class="grid-col-auto">
+              <p class="usa-footer__logo-heading"></p>
             </div>
           </div>
         </div>
-        <div class="usa-footer__secondary-section">
-          <div class="grid-container">
-            <div class="usa-footer__logo grid-row grid-gap-2">
-              <div class="grid-col-auto">
-                <img class="usa-footer__logo-img" src="/assets/img/logo-img.png" alt="">
-              </div>
-              <div class="grid-col-auto">
-                <p class="usa-footer__logo-heading"></p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </footer>
+      </div>
+    </footer>
   </body>
 </html>

--- a/retire.html
+++ b/retire.html
@@ -79,7 +79,7 @@
         <div class="usa-nav__inner"><button class="usa-nav__close"><img src="/assets/img/usa-icons/close.svg" role="img" alt="close"></button>
    
    
-            <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item">
+            <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item" style="display: none">
         <button class="usa-accordion__button usa-nav__link  " aria-expanded="false" aria-controls="extended-nav-section-one"><span>CMS Rapid ATO</span></button>
         <ul id="extended-nav-section-one" class="usa-nav__submenu">
        

--- a/roles.html
+++ b/roles.html
@@ -79,7 +79,7 @@
         <div class="usa-nav__inner"><button class="usa-nav__close"><img src="/assets/img/usa-icons/close.svg" role="img" alt="close"></button>
    
    
-            <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item">
+            <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item" style="display: none">
         <button class="usa-accordion__button usa-nav__link  " aria-expanded="false" aria-controls="extended-nav-section-one"><span>CMS Rapid ATO</span></button>
         <ul id="extended-nav-section-one" class="usa-nav__submenu">
        

--- a/tools.html
+++ b/tools.html
@@ -79,7 +79,7 @@
         <div class="usa-nav__inner"><button class="usa-nav__close"><img src="/assets/img/usa-icons/close.svg" role="img" alt="close"></button>
    
    
-            <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item">
+            <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item" style="display: none ">
         <button class="usa-accordion__button usa-nav__link  " aria-expanded="false" aria-controls="extended-nav-section-one"><span>CMS Rapid ATO</span></button>
         <ul id="extended-nav-section-one" class="usa-nav__submenu">
        

--- a/types.html
+++ b/types.html
@@ -79,7 +79,7 @@
         <div class="usa-nav__inner"><button class="usa-nav__close"><img src="/assets/img/usa-icons/close.svg" role="img" alt="close"></button>
    
    
-            <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item">
+            <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item" style="display: none">
         <button class="usa-accordion__button usa-nav__link  " aria-expanded="false" aria-controls="extended-nav-section-one"><span>CMS Rapid ATO</span></button>
         <ul id="extended-nav-section-one" class="usa-nav__submenu">
        


### PR DESCRIPTION
Keeping the website content as relevant as possible as this prepares to transition to security.cms.gov in November 2022. Rapid ATO has ended and is not continuing to FY2023, so I'm: 
- replacing the index.html Rapid ATO welcome page, with the ATO overview page (that lists the life cycle of an ATO) 
- Making menu items related to Rapid ATO invisible via styling